### PR TITLE
Google Apps are incompatible with x86, remove them

### DIFF
--- a/config/mk_prebuilt.mk
+++ b/config/mk_prebuilt.mk
@@ -25,8 +25,10 @@ PRODUCT_COPY_FILES += \
 endif
 
 # Google apps
+ifneq ($(filter armeabi armeabi-v7a arm64-v8a,$(MK_CPU_ABI)),)
 PRODUCT_COPY_FILES += \
     $(call find-copy-subdir-files,*,vendor/mk/prebuilt/google/app,system/app)
+endif
 
 # ViPER4Android
 ifneq ($(filter armeabi armeabi-v7a,$(MK_CPU_ABI)),)


### PR DESCRIPTION
I've removed this to include LatinIME from CyanogenMod Repositories
